### PR TITLE
More fixes

### DIFF
--- a/metabonding/Cargo.toml
+++ b/metabonding/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.29.2"
+version = "0.30.0"
 
 [dependencies.elrond-wasm-modules]
-version = "0.29.2"
+version = "0.30.0"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.29.2"
+version = "0.30.0"

--- a/metabonding/mandos/claim_rewards_first_week.scen.json
+++ b/metabonding/mandos/claim_rewards_first_week.scen.json
@@ -52,8 +52,7 @@
                 "to": "sc:meta",
                 "function": "getUserClaimableWeeks",
                 "arguments": [
-                    "address:user1",
-                    "1"
+                    "address:user1"
                 ]
             },
             "expect": {
@@ -127,8 +126,7 @@
                 "to": "sc:meta",
                 "function": "getUserClaimableWeeks",
                 "arguments": [
-                    "address:user1",
-                    "1"
+                    "address:user1"
                 ]
             },
             "expect": {

--- a/metabonding/meta/Cargo.toml
+++ b/metabonding/meta/Cargo.toml
@@ -11,7 +11,7 @@ authors = [ "Dorin Marian Iancu, dorin.iancu@elrond.com" ]
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.29.2"
+version = "0.30.0"
 
 [dependencies.elrond-wasm-debug]
-version = "0.29.2"
+version = "0.30.0"

--- a/metabonding/src/access_control.rs
+++ b/metabonding/src/access_control.rs
@@ -1,0 +1,14 @@
+elrond_wasm::imports!();
+
+#[elrond_wasm::module]
+pub trait AccessControlModule: crate::common_storage::CommonStorageModule {
+    fn require_caller_owner_or_signer(&self) {
+        let caller = self.blockchain().get_caller();
+        let owner = self.blockchain().get_owner_address();
+        let signer = self.signer().get();
+        require!(
+            caller == owner || caller == signer,
+            "Only owner or signer may call this function"
+        );
+    }
+}

--- a/metabonding/src/common_storage.rs
+++ b/metabonding/src/common_storage.rs
@@ -1,0 +1,23 @@
+elrond_wasm::imports!();
+
+use crate::project::Epoch;
+use elrond_wasm::elrond_codec::TopEncode;
+
+pub const EPOCHS_IN_WEEK: Epoch = 7;
+pub const MAX_PERCENTAGE: u64 = 100;
+
+#[elrond_wasm::module]
+pub trait CommonStorageModule {
+    fn get_and_clear<T: TopEncode + TopDecode>(&self, mapper: &SingleValueMapper<T>) -> T {
+        let value = mapper.get();
+        mapper.clear();
+
+        value
+    }
+
+    #[storage_mapper("signer")]
+    fn signer(&self) -> SingleValueMapper<ManagedAddress>;
+
+    #[storage_mapper("firstWeekStartEpoch")]
+    fn first_week_start_epoch(&self) -> SingleValueMapper<Epoch>;
+}

--- a/metabonding/src/lib.rs
+++ b/metabonding/src/lib.rs
@@ -20,12 +20,20 @@ pub trait Metabonding:
     + util::UtilModule
 {
     #[init]
-    fn init(&self, signer: ManagedAddress) {
+    fn init(
+        &self,
+        signer: ManagedAddress,
+        #[var_args] opt_first_week_start_epoch: OptionalValue<u64>,
+    ) {
         self.signer().set(&signer);
         self.set_paused(true);
 
-        let current_epoch = self.blockchain().get_block_epoch();
-        self.first_week_start_epoch().set_if_empty(&current_epoch);
+        let first_week_start_epoch = match opt_first_week_start_epoch {
+            OptionalValue::Some(epoch) => epoch,
+            OptionalValue::None => self.blockchain().get_block_epoch(),
+        };
+        self.first_week_start_epoch()
+            .set_if_empty(&first_week_start_epoch);
     }
 
     #[only_owner]

--- a/metabonding/src/lib.rs
+++ b/metabonding/src/lib.rs
@@ -78,13 +78,8 @@ pub trait Metabonding:
                     .update(|leftover| *leftover -= &payment.amount);
             }
 
-            let _ = Self::Api::send_api_impl().direct_multi_esdt_transfer_execute(
-                &caller,
-                &weekly_rewards.payments,
-                0,
-                &ManagedBuffer::new(),
-                &ManagedArgBuffer::new_empty(),
-            );
+            self.send()
+                .direct_multi(&caller, &weekly_rewards.payments, &[]);
         }
     }
 

--- a/metabonding/src/math.rs
+++ b/metabonding/src/math.rs
@@ -1,0 +1,19 @@
+elrond_wasm::imports!();
+
+use crate::rewards::Week;
+
+#[elrond_wasm::module]
+pub trait MathModule {
+    fn calculate_ratio(&self, amount: &BigUint, part: &BigUint, total: &BigUint) -> BigUint {
+        if total == &0 {
+            return BigUint::zero();
+        }
+
+        &(amount * part) / total
+    }
+
+    #[inline]
+    fn is_in_range(&self, value: Week, min: Week, max: Week) -> bool {
+        (min..=max).contains(&value)
+    }
+}

--- a/metabonding/src/project.rs
+++ b/metabonding/src/project.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use core::convert::TryInto;
 
-const PROJECT_EXPIRATION_WEEKS: Week = 4;
+pub const PROJECT_EXPIRATION_WEEKS: Week = 4;
 const MAX_PROJECT_ID_LEN: usize = 10;
 const MIN_GAS_FOR_CLEAR: u64 = 5_000_000;
 const INVALID_PROJECT_ID_ERR_MSG: &[u8] = b"Invalid project ID";

--- a/metabonding/src/project.rs
+++ b/metabonding/src/project.rs
@@ -6,7 +6,7 @@ use core::convert::TryInto;
 use elrond_codec::TopEncode;
 
 const EPOCHS_IN_WEEK: Epoch = 7;
-const PROJECT_EXPIRATION_WEEKS: Week = 1;
+const PROJECT_EXPIRATION_WEEKS: Week = 4;
 const MAX_PROJECT_ID_LEN: usize = 10;
 const MIN_GAS_FOR_CLEAR: u64 = 5_000_000;
 const INVALID_PROJECT_ID_ERR_MSG: &[u8] = b"Invalid project ID";

--- a/metabonding/src/rewards.rs
+++ b/metabonding/src/rewards.rs
@@ -1,8 +1,11 @@
 elrond_wasm::imports!();
 elrond_wasm::derive_imports!();
 
-use crate::project::{Project, ProjectId};
-use core::ops::Deref;
+use crate::{
+    project::{Project, ProjectId},
+    validation::Signature,
+};
+use core::{borrow::Borrow, ops::Deref};
 
 pub type Week = usize;
 pub type PrettyRewards<M> =
@@ -36,7 +39,14 @@ impl<M: ManagedTypeApi> WeeklyRewards<M> {
 }
 
 #[elrond_wasm::module]
-pub trait RewardsModule: crate::project::ProjectModule + crate::util::UtilModule {
+pub trait RewardsModule:
+    elrond_wasm_modules::pause::PauseModule
+    + crate::project::ProjectModule
+    + crate::access_control::AccessControlModule
+    + crate::common_storage::CommonStorageModule
+    + crate::math::MathModule
+    + crate::validation::ValidationModule
+{
     #[endpoint(addRewardsCheckpoint)]
     fn add_rewards_checkpoint(
         &self,
@@ -69,10 +79,7 @@ pub trait RewardsModule: crate::project::ProjectModule + crate::util::UtilModule
         );
 
         let (payment_amount, payment_token) = self.call_value().payment_token_pair();
-        let project: Project<Self::Api> = match self.projects().get(&project_id) {
-            Some(p) => p,
-            None => sc_panic!("Invalid project ID"),
-        };
+        let project = self.get_project_or_panic(&project_id);
 
         let current_week = self.get_current_week();
         require!(
@@ -88,6 +95,54 @@ pub trait RewardsModule: crate::project::ProjectModule + crate::util::UtilModule
         require!(total_reward_supply == payment_amount, "Invalid amount");
 
         self.rewards_deposited(&project_id).set(&true);
+    }
+
+    #[endpoint(claimRewards)]
+    fn claim_rewards(
+        &self,
+        week: Week,
+        user_delegation_amount: BigUint,
+        user_lkmex_staked_amount: BigUint,
+        signature: Signature<Self::Api>,
+    ) {
+        require!(self.not_paused(), "May not claim rewards while paused");
+
+        let caller = self.blockchain().get_caller();
+        require!(
+            !self.rewards_claimed(&caller, week).get(),
+            "Already claimed rewards for this week"
+        );
+
+        let last_checkpoint_week = self.get_last_checkpoint_week();
+        require!(week <= last_checkpoint_week, "No checkpoint for week yet");
+
+        let checkpoint: RewardsCheckpoint<Self::Api> = self.rewards_checkpoints().get(week);
+        self.verify_signature(
+            week,
+            &caller,
+            &user_delegation_amount,
+            &user_lkmex_staked_amount,
+            &signature,
+        );
+
+        self.rewards_claimed(&caller, week).set(&true);
+
+        let weekly_rewards = self.get_rewards_for_week(
+            week,
+            &user_delegation_amount,
+            &user_lkmex_staked_amount,
+            &checkpoint.total_delegation_supply,
+            &checkpoint.total_lkmex_staked,
+        );
+        if !weekly_rewards.is_empty() {
+            for (id, payment) in weekly_rewards.iter() {
+                self.leftover_project_funds(id.borrow())
+                    .update(|leftover| *leftover -= &payment.amount);
+            }
+
+            self.send()
+                .direct_multi(&caller, &weekly_rewards.payments, &[]);
+        }
     }
 
     #[view(getUserClaimableWeeks)]

--- a/metabonding/src/rewards.rs
+++ b/metabonding/src/rewards.rs
@@ -89,15 +89,15 @@ pub trait RewardsModule: crate::project::ProjectModule {
         user_address: ManagedAddress,
         number_weeks_to_look_back: Week,
     ) -> MultiValueEncoded<Week> {
-        let current_week = self.get_current_week();
-        let start_week = if number_weeks_to_look_back >= current_week {
+        let last_checkpoint_week = self.get_last_checkpoint_week();
+        let start_week = if number_weeks_to_look_back >= last_checkpoint_week {
             1
         } else {
-            current_week - number_weeks_to_look_back
+            last_checkpoint_week - number_weeks_to_look_back
         };
 
         let mut weeks_list = MultiValueEncoded::new();
-        for week in start_week..=current_week {
+        for week in start_week..=last_checkpoint_week {
             if !self.rewards_claimed(&user_address, week).get() {
                 weeks_list.push(week);
             }

--- a/metabonding/src/util.rs
+++ b/metabonding/src/util.rs
@@ -1,0 +1,61 @@
+elrond_wasm::imports!();
+
+use elrond_wasm::api::ED25519_SIGNATURE_BYTE_LEN;
+
+use crate::rewards::Week;
+
+const MAX_DATA_LEN: usize = 80; // 4 + 32 + 32, with some extra for high BigUint values
+
+pub type Signature<M> = ManagedByteArray<M, ED25519_SIGNATURE_BYTE_LEN>;
+
+#[elrond_wasm::module]
+pub trait UtilModule {
+    fn require_caller_owner_or_signer(&self) {
+        let caller = self.blockchain().get_caller();
+        let owner = self.blockchain().get_owner_address();
+        let signer = self.signer().get();
+        require!(
+            caller == owner || caller == signer,
+            "Only owner or signer may call this function"
+        );
+    }
+
+    fn verify_signature(
+        &self,
+        week: Week,
+        caller: &ManagedAddress,
+        user_delegation_amount: &BigUint,
+        user_lkmex_staked_amount: &BigUint,
+        signature: &Signature<Self::Api>,
+    ) {
+        let mut data = ManagedBuffer::new();
+        let _ = week.dep_encode(&mut data);
+        data.append(caller.as_managed_buffer());
+        let _ = user_delegation_amount.dep_encode(&mut data);
+        let _ = user_lkmex_staked_amount.dep_encode(&mut data);
+
+        let signer: ManagedAddress = self.signer().get();
+        let valid_signature = self.crypto().verify_ed25519_managed::<MAX_DATA_LEN>(
+            signer.as_managed_byte_array(),
+            &data,
+            signature,
+        );
+        require!(valid_signature, "Invalid signature");
+    }
+
+    #[inline]
+    fn is_in_range(&self, value: Week, min: Week, max: Week) -> bool {
+        (min..=max).contains(&value)
+    }
+
+    fn calculate_ratio(&self, amount: &BigUint, part: &BigUint, total: &BigUint) -> BigUint {
+        if total == &0 {
+            return BigUint::zero();
+        }
+
+        &(amount * part) / total
+    }
+
+    #[storage_mapper("signer")]
+    fn signer(&self) -> SingleValueMapper<ManagedAddress>;
+}

--- a/metabonding/wasm/Cargo.toml
+++ b/metabonding/wasm/Cargo.toml
@@ -24,8 +24,8 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.29.2"
+version = "0.30.0"
 
 [dependencies.elrond-wasm-output]
-version = "0.29.2"
+version = "0.30.0"
 features = [ "wasm-output-mode",]


### PR DESCRIPTION
- upgrade to elrond-wasm 0.30.0
- `get_user_claimable_weeks` now checks the last X weeks from the last checkpoint week instead of current week
- move some of the more generic checks to a separate "UtilModule"
- no rewards for expired projects + also disallow despositing rewards for already expired projects
- allow first week start epoch to be set on init