### PR TITLE
remove rewards deposit check

### DIFF
--- a/metabonding/mandos/project_in_the_past.scen.json
+++ b/metabonding/mandos/project_in_the_past.scen.json
@@ -194,6 +194,19 @@
                 "gas": "*",
                 "refund": "*"
             }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:user1": {
+                    "nonce": "*",
+                    "balance": "0",
+                    "esdt": {
+                        "str:PROJ-123456": "35,714,285"
+                    }
+                },
+                "+": ""
+            }
         }
     ]
 }

--- a/metabonding/mandos/project_in_the_past.scen.json
+++ b/metabonding/mandos/project_in_the_past.scen.json
@@ -1,0 +1,199 @@
+{
+    "steps": [
+        {
+            "step": "externalSteps",
+            "path": "init.scen.json"
+        },
+        {
+            "step": "setState",
+            "comment": "week 5",
+            "currentBlockInfo": {
+                "blockEpoch": "41"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "add-first-project-with-start-date-in-the-past",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:meta",
+                "function": "addProject",
+                "arguments": [
+                    "str:FirstProj",
+                    "address:project_owner1",
+                    "str:PROJ-123456",
+                    "1,000,000,000",
+                    "1",
+                    "7",
+                    "0"
+                ],
+                "gasLimit": "10,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "0",
+                "logs": "*",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "get-all-project-ids",
+            "tx": {
+                "to": "sc:meta",
+                "function": "getAllProjectIds",
+                "arguments": []
+            },
+            "expect": {
+                "out": [
+                    "str:FirstProj"
+                ],
+                "status": "0",
+                "logs": "*"
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "get-first-project",
+            "tx": {
+                "to": "sc:meta",
+                "function": "getProjectById",
+                "arguments": [
+                    "str:FirstProj"
+                ]
+            },
+            "expect": {
+                "out": [
+                    "str:PROJ-123456",
+                    "1,000,000,000",
+                    "0",
+                    "1",
+                    "7"
+                ],
+                "status": "0",
+                "logs": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "deposit-rewards-first-project",
+            "tx": {
+                "from": "address:project_owner1",
+                "to": "sc:meta",
+                "esdtValue": [
+                    {
+                        "tokenIdentifier": "str:PROJ-123456",
+                        "value": "1,000,000,000"
+                    }
+                ],
+                "function": "depositRewards",
+                "arguments": [
+                    "str:FirstProj"
+                ],
+                "gasLimit": "10,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "0",
+                "logs": "*",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "user-1-try-claim",
+            "tx": {
+                "from": "address:user1",
+                "to": "sc:meta",
+                "function": "claimRewards",
+                "arguments": [
+                    "1",
+                    "25,000",
+                    "0",
+                    "0xd47c0d67b2d25de8b4a3f43d91a2b5ccb522afac47321ae80bf89c90a4445b26adefa693ab685fa20891f736d74eb2dedc11c4b1a8d6e642fa28df270d6ebe08"
+                ],
+                "gasLimit": "10,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "4",
+                "message": "str:May not claim rewards while paused",
+                "logs": "*",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "add-first-checkpoint",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:meta",
+                "function": "addRewardsCheckpoint",
+                "arguments": [
+                    "1",
+                    "100,000",
+                    "0"
+                ],
+                "gasLimit": "10,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "0",
+                "logs": "*",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "unpause",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:meta",
+                "function": "unpause",
+                "arguments": [],
+                "gasLimit": "10,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "0",
+                "logs": "*",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "user-1-claim",
+            "tx": {
+                "from": "address:user1",
+                "to": "sc:meta",
+                "function": "claimRewards",
+                "arguments": [
+                    "1",
+                    "25,000",
+                    "0",
+                    "0xd47c0d67b2d25de8b4a3f43d91a2b5ccb522afac47321ae80bf89c90a4445b26adefa693ab685fa20891f736d74eb2dedc11c4b1a8d6e642fa28df270d6ebe08"
+                ],
+                "gasLimit": "10,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "0",
+                "message": "",
+                "logs": "*",
+                "gas": "*",
+                "refund": "*"
+            }
+        }
+    ]
+}

--- a/metabonding/src/project.rs
+++ b/metabonding/src/project.rs
@@ -27,11 +27,9 @@ pub struct Project<M: ManagedTypeApi> {
 }
 
 impl<M: ManagedTypeApi> Project<M> {
-    pub fn is_expired(&self, current_week: Week, were_rewards_deposited: bool) -> bool {
-        if current_week > self.end_week + PROJECT_EXPIRATION_WEEKS {
-            return true;
-        }
-        !were_rewards_deposited && current_week >= self.start_week
+    #[inline]
+    pub fn is_expired(&self, current_week: Week) -> bool {
+        current_week > self.end_week + PROJECT_EXPIRATION_WEEKS
     }
 
     #[inline]
@@ -126,8 +124,7 @@ pub trait ProjectModule: crate::common_storage::CommonStorageModule {
                 clear_prev_id = false;
             }
 
-            let were_rewards_deposited = self.rewards_deposited(&id).get();
-            if project.is_expired(current_week, were_rewards_deposited) {
+            if project.is_expired(current_week) {
                 prev_token = project.reward_token;
                 prev_id = id;
                 clear_prev_id = true;

--- a/metabonding/src/rewards.rs
+++ b/metabonding/src/rewards.rs
@@ -82,10 +82,7 @@ pub trait RewardsModule:
         let project = self.get_project_or_panic(&project_id);
 
         let current_week = self.get_current_week();
-        require!(
-            !project.is_expired(current_week, false),
-            "Project is expired"
-        );
+        require!(!project.is_expired(current_week), "Project is expired");
 
         let total_reward_supply = project.lkmex_reward_supply + project.delegation_reward_supply;
         require!(
@@ -216,7 +213,7 @@ pub trait RewardsModule:
             if !self.rewards_deposited(&id).get() {
                 continue;
             }
-            if project.is_expired(current_week, true) {
+            if project.is_expired(current_week) {
                 continue;
             }
 


### PR DESCRIPTION
- this allows us to start the contract on "pause" and setup projects with start date in the past. This was allowed due to the previous PR as well, but rewards could not be deposited (a project that did not deposit rewards until its start week was considered expired)