### PR TITLE
revert multiple claim change + setup for next pr

### DIFF
--- a/metabonding/src/lib.rs
+++ b/metabonding/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
-
-use rewards::Week;
+#![feature(generic_associated_types)]
 
 elrond_wasm::imports!();
 
@@ -8,8 +7,11 @@ pub mod access_control;
 pub mod common_storage;
 pub mod math;
 pub mod project;
+pub mod reward_data_types;
 pub mod rewards;
 pub mod validation;
+
+use reward_data_types::Week;
 
 /// Source code for the pause module:
 /// https://github.com/ElrondNetwork/elrond-wasm-rs/blob/master/elrond-wasm-modules/src/pause.rs

--- a/metabonding/src/math.rs
+++ b/metabonding/src/math.rs
@@ -1,6 +1,6 @@
 elrond_wasm::imports!();
 
-use crate::rewards::Week;
+use crate::reward_data_types::Week;
 
 #[elrond_wasm::module]
 pub trait MathModule {

--- a/metabonding/src/reward_data_types.rs
+++ b/metabonding/src/reward_data_types.rs
@@ -1,0 +1,58 @@
+elrond_wasm::imports!();
+elrond_wasm::derive_imports!();
+
+use crate::{project::ProjectId, validation::Signature};
+
+pub type Week = usize;
+pub type PaymentsVec<M> = ManagedVec<M, EsdtTokenPayment<M>>;
+pub type PrettyRewards<M> =
+    MultiValueEncoded<M, MultiValue3<ProjectId<M>, TokenIdentifier<M>, BigUint<M>>>;
+pub type ClaimArgPair<M> = MultiValue4<Week, BigUint<M>, BigUint<M>, Signature<M>>;
+
+#[derive(TypeAbi, TopEncode, TopDecode)]
+pub struct RewardsCheckpoint<M: ManagedTypeApi> {
+    pub total_delegation_supply: BigUint<M>,
+    pub total_lkmex_staked: BigUint<M>,
+}
+
+pub struct WeeklyRewards<M: ManagedTypeApi> {
+    payments: PaymentsVec<M>,
+}
+
+impl<M: ManagedTypeApi> WeeklyRewards<M> {
+    #[inline]
+    pub fn new(payments: PaymentsVec<M>) -> Self {
+        Self { payments }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.payments.is_empty()
+    }
+
+    pub fn add_rewards(&mut self, other: WeeklyRewards<M>) {
+        let payments_len = self.payments.len();
+        for i in 0..payments_len {
+            let mut payment = self.payments.get_mut(i);
+            payment.amount += other.payments.get(i).amount;
+        }
+    }
+
+    pub fn get_trimmed_payments(
+        self,
+        project_ids: &mut ManagedVec<M, ProjectId<M>>,
+    ) -> ManagedVec<M, EsdtTokenPayment<M>> {
+        let mut proj_index = 0;
+        let mut trimmed_payments = ManagedVec::new();
+        for p in &self.payments {
+            if p.amount > 0 {
+                trimmed_payments.push(p);
+                proj_index += 1;
+            } else {
+                project_ids.remove(proj_index);
+            }
+        }
+
+        trimmed_payments
+    }
+}

--- a/metabonding/src/rewards.rs
+++ b/metabonding/src/rewards.rs
@@ -2,42 +2,11 @@ elrond_wasm::imports!();
 elrond_wasm::derive_imports!();
 
 use crate::{
-    project::{Project, ProjectId, PROJECT_EXPIRATION_WEEKS},
+    project::{Project, ProjectId, ProjectsMapperCache, PROJECT_EXPIRATION_WEEKS},
+    reward_data_types::*,
     validation::Signature,
 };
 use core::{borrow::Borrow, ops::Deref};
-
-pub type Week = usize;
-pub type PrettyRewards<M> =
-    MultiValueEncoded<M, MultiValue3<ProjectId<M>, TokenIdentifier<M>, BigUint<M>>>;
-pub type ClaimArgPair<M> = MultiValue4<Week, BigUint<M>, BigUint<M>, Signature<M>>;
-
-#[derive(TypeAbi, TopEncode, TopDecode)]
-pub struct RewardsCheckpoint<M: ManagedTypeApi> {
-    pub total_delegation_supply: BigUint<M>,
-    pub total_lkmex_staked: BigUint<M>,
-}
-
-pub struct WeeklyRewards<M: ManagedTypeApi> {
-    pub project_ids: ManagedVec<M, ProjectId<M>>,
-    pub payments: ManagedVec<M, EsdtTokenPayment<M>>,
-}
-
-impl<M: ManagedTypeApi> WeeklyRewards<M> {
-    pub fn iter(
-        &self,
-    ) -> core::iter::Zip<
-        ManagedVecRefIterator<M, ProjectId<M>>,
-        ManagedVecRefIterator<M, EsdtTokenPayment<M>>,
-    > {
-        self.project_ids.iter().zip(self.payments.iter())
-    }
-
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.project_ids.is_empty()
-    }
-}
 
 #[elrond_wasm::module]
 pub trait RewardsModule:
@@ -104,61 +73,65 @@ pub trait RewardsModule:
         self.rewards_deposited(&project_id).set(&true);
     }
 
-    /// args are pairs of:
-    /// - week: unsigned number,
-    /// - user_delegation_amount: BigUint,
-    /// - user_lkmex_staked_amount: BigUint,
-    /// - signature: 120 bytes,
     #[endpoint(claimRewards)]
-    fn claim_rewards(&self, #[var_args] arg_pairs: MultiValueEncoded<ClaimArgPair<Self::Api>>) {
+    fn claim_rewards(
+        &self,
+        week: Week,
+        user_delegation_amount: BigUint,
+        user_lkmex_staked_amount: BigUint,
+        signature: Signature<Self::Api>,
+    ) {
         require!(self.not_paused(), "May not claim rewards while paused");
 
         let caller = self.blockchain().get_caller();
-        let current_week = self.get_current_week();
+        require!(
+            !self.rewards_claimed(&caller, week).get(),
+            "Already claimed rewards for this week"
+        );
+
         let last_checkpoint_week = self.get_last_checkpoint_week();
+        require!(week <= last_checkpoint_week, "No checkpoint for week yet");
+
+        let current_week = self.get_current_week();
         let rewards_nr_first_grace_weeks = self.rewards_nr_first_grace_weeks().get();
+        require!(
+            self.is_claim_in_time(week, current_week, rewards_nr_first_grace_weeks),
+            "Claiming too late"
+        );
 
-        for arg_pair in arg_pairs {
-            let (week, user_delegation_amount, user_lkmex_staked_amount, signature) =
-                arg_pair.into_tuple();
+        let checkpoint: RewardsCheckpoint<Self::Api> = self.rewards_checkpoints().get(week);
+        self.verify_signature(
+            week,
+            &caller,
+            &user_delegation_amount,
+            &user_lkmex_staked_amount,
+            &signature,
+        );
 
-            require!(
-                !self.rewards_claimed(&caller, week).get(),
-                "Already claimed rewards for this week"
-            );
-            require!(week <= last_checkpoint_week, "No checkpoint for week yet");
-            require!(
-                self.is_claim_in_time(week, current_week, rewards_nr_first_grace_weeks),
-                "Claiming too late"
-            );
+        self.rewards_claimed(&caller, week).set(&true);
 
-            let checkpoint: RewardsCheckpoint<Self::Api> = self.rewards_checkpoints().get(week);
-            self.verify_signature(
-                week,
-                &caller,
-                &user_delegation_amount,
-                &user_lkmex_staked_amount,
-                &signature,
-            );
+        let mut projects_cache = self.get_projects_mapper_cache();
+        let weekly_rewards = self.get_rewards_for_week(
+            &projects_cache,
+            week,
+            &user_delegation_amount,
+            &user_lkmex_staked_amount,
+            &checkpoint.total_delegation_supply,
+            &checkpoint.total_lkmex_staked,
+        );
+        let trimmed_payments = weekly_rewards.get_trimmed_payments(&mut projects_cache.project_ids);
 
-            self.rewards_claimed(&caller, week).set(&true);
-
-            let weekly_rewards = self.get_rewards_for_week(
-                week,
-                &user_delegation_amount,
-                &user_lkmex_staked_amount,
-                &checkpoint.total_delegation_supply,
-                &checkpoint.total_lkmex_staked,
-            );
-            if !weekly_rewards.is_empty() {
-                for (id, payment) in weekly_rewards.iter() {
-                    self.leftover_project_funds(id.borrow())
-                        .update(|leftover| *leftover -= &payment.amount);
-                }
-
-                self.send()
-                    .direct_multi(&caller, &weekly_rewards.payments, &[]);
+        if !trimmed_payments.is_empty() {
+            for (id, payment) in projects_cache
+                .project_ids
+                .iter()
+                .zip(trimmed_payments.iter())
+            {
+                self.leftover_project_funds(id.borrow())
+                    .update(|leftover| *leftover -= &payment.amount);
             }
+
+            self.send().direct_multi(&caller, &trimmed_payments, &[]);
         }
     }
 
@@ -196,16 +169,23 @@ pub trait RewardsModule:
         user_lkmex_staked_amount: BigUint,
     ) -> PrettyRewards<Self::Api> {
         let checkpoint: RewardsCheckpoint<Self::Api> = self.rewards_checkpoints().get(week);
+        let mut projects_cache = self.get_projects_mapper_cache();
         let weekly_rewards = self.get_rewards_for_week(
+            &projects_cache,
             week,
             &user_delegation_amount,
             &user_lkmex_staked_amount,
             &checkpoint.total_delegation_supply,
             &checkpoint.total_lkmex_staked,
         );
+        let trimmed_payments = weekly_rewards.get_trimmed_payments(&mut projects_cache.project_ids);
 
         let mut rewards_pretty = MultiValueEncoded::new();
-        for (id, payment) in weekly_rewards.iter() {
+        for (id, payment) in projects_cache
+            .project_ids
+            .iter()
+            .zip(trimmed_payments.iter())
+        {
             rewards_pretty
                 .push((id.deref().clone(), payment.token_identifier, payment.amount).into());
         }
@@ -213,8 +193,11 @@ pub trait RewardsModule:
         rewards_pretty
     }
 
+    fn get_rewards_multiple_weeks(&self) {}
+
     fn get_rewards_for_week(
         &self,
+        projects_cache: &ProjectsMapperCache<Self::Api>,
         week: Week,
         user_delegation_amount: &BigUint,
         user_lkmex_staked_amount: &BigUint,
@@ -222,44 +205,39 @@ pub trait RewardsModule:
         total_lkmex_staked: &BigUint,
     ) -> WeeklyRewards<Self::Api> {
         let current_week = self.get_current_week();
-        let mut project_ids = ManagedVec::new();
         let mut user_rewards = ManagedVec::new();
 
-        for (id, project) in self.projects().iter() {
+        for (id, project) in projects_cache.iter() {
+            let mut is_zero_amount = false;
             if !self.is_in_range(week, project.start_week, project.end_week) {
-                continue;
-            }
-            if !self.rewards_deposited(&id).get() {
-                continue;
-            }
-            if project.is_expired(current_week) {
-                continue;
+                is_zero_amount = true;
+            } else if !self.rewards_deposited(&id).get() {
+                is_zero_amount = true;
+            } else if project.is_expired(current_week) {
+                is_zero_amount = true;
             }
 
-            let reward_amount = self.calculate_reward_amount(
-                &project,
-                user_delegation_amount,
-                user_lkmex_staked_amount,
-                total_delegation_supply,
-                total_lkmex_staked,
-            );
-            if reward_amount > 0 {
-                project_ids.push(id);
-
-                let user_payment = EsdtTokenPayment {
-                    token_type: EsdtTokenType::Fungible,
-                    token_identifier: project.reward_token,
-                    token_nonce: 0,
-                    amount: reward_amount,
-                };
-                user_rewards.push(user_payment);
-            }
+            let reward_amount = if is_zero_amount {
+                BigUint::zero()
+            } else {
+                self.calculate_reward_amount(
+                    &project,
+                    user_delegation_amount,
+                    user_lkmex_staked_amount,
+                    total_delegation_supply,
+                    total_lkmex_staked,
+                )
+            };
+            let user_payment = EsdtTokenPayment {
+                token_type: EsdtTokenType::Fungible,
+                token_identifier: project.reward_token,
+                token_nonce: 0,
+                amount: reward_amount,
+            };
+            user_rewards.push(user_payment);
         }
 
-        WeeklyRewards {
-            project_ids,
-            payments: user_rewards,
-        }
+        WeeklyRewards::new(user_rewards)
     }
 
     fn calculate_reward_amount(

--- a/metabonding/src/rewards.rs
+++ b/metabonding/src/rewards.rs
@@ -208,14 +208,9 @@ pub trait RewardsModule:
         let mut user_rewards = ManagedVec::new();
 
         for (id, project) in projects_cache.iter() {
-            let mut is_zero_amount = false;
-            if !self.is_in_range(week, project.start_week, project.end_week) {
-                is_zero_amount = true;
-            } else if !self.rewards_deposited(&id).get() {
-                is_zero_amount = true;
-            } else if project.is_expired(current_week) {
-                is_zero_amount = true;
-            }
+            let is_zero_amount = !self.is_in_range(week, project.start_week, project.end_week)
+                || !self.rewards_deposited(&id).get()
+                || project.is_expired(current_week);
 
             let reward_amount = if is_zero_amount {
                 BigUint::zero()

--- a/metabonding/src/validation.rs
+++ b/metabonding/src/validation.rs
@@ -1,6 +1,6 @@
 elrond_wasm::imports!();
 
-use crate::rewards::Week;
+use crate::reward_data_types::Week;
 use elrond_wasm::api::ED25519_SIGNATURE_BYTE_LEN;
 
 // week + caller + user_delegation_amount + user_lkmex_staked_amount

--- a/metabonding/tests/metabonding_setup/mod.rs
+++ b/metabonding/tests/metabonding_setup/mod.rs
@@ -1,7 +1,5 @@
 use elrond_wasm::{
-    api::ED25519_SIGNATURE_BYTE_LEN,
-    elrond_codec::multi_types::OptionalValue,
-    types::{Address, MultiValueEncoded},
+    api::ED25519_SIGNATURE_BYTE_LEN, elrond_codec::multi_types::OptionalValue, types::Address,
 };
 use elrond_wasm_debug::{
     managed_address, managed_biguint, managed_buffer, managed_token_id, rust_biguint,
@@ -15,7 +13,7 @@ use metabonding::rewards::RewardsModule;
 use metabonding::*;
 use metabonding::{
     common_storage::{CommonStorageModule, EPOCHS_IN_WEEK},
-    rewards::Week,
+    reward_data_types::*,
 };
 
 // associated private key - used for generating the signatures (please don't steal my funds)
@@ -347,18 +345,12 @@ where
     ) -> TxResult {
         self.b_mock
             .execute_tx(caller, &self.mb_wrapper, &rust_biguint!(0), |sc| {
-                let mut args = MultiValueEncoded::new();
-                args.push(
-                    (
-                        week,
-                        managed_biguint!(user_delegation_supply),
-                        managed_biguint!(user_lkmex_staked),
-                        signature.into(),
-                    )
-                        .into(),
+                sc.claim_rewards(
+                    week,
+                    managed_biguint!(user_delegation_supply),
+                    managed_biguint!(user_lkmex_staked),
+                    signature.into(),
                 );
-
-                sc.claim_rewards(args);
             })
     }
 


### PR DESCRIPTION
- revert previous PR and make claimRewards single-claim again
- prepare the data types for multiple claim functionality

This PR is just to ensure nothing is broken when implementing multi-claim. It will be done in a separate endpoint in next PR.