### PR TITLE
remove grace weeks logic

### DIFF
--- a/metabonding/src/lib.rs
+++ b/metabonding/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-use rewards::Week;
-
 multiversx_sc::imports!();
 
 pub mod access_control;
@@ -30,27 +28,13 @@ pub trait Metabonding:
 {
     /// Arguments:
     /// - signer - public key that will be used for checking the claim signatures
-    /// - opt_rewards_nr_first_grace_weeks - Optional argument that will make it so
-    ///     the first X weeks can be claimed at any time (i.e. they will never expire)
     /// - opt_first_week_start_epoch - The epoch which signals the start of week 0.
     ///     Can also be an epoch from the past.
     ///     By default, the current epoch on deploy will be used
     #[init]
-    fn init(
-        &self,
-        signer: ManagedAddress,
-        opt_rewards_nr_first_grace_weeks: OptionalValue<Week>,
-        opt_first_week_start_epoch: OptionalValue<u64>,
-    ) {
+    fn init(&self, signer: ManagedAddress, opt_first_week_start_epoch: OptionalValue<u64>) {
         self.signer().set(&signer);
         self.set_paused(true);
-
-        let rewards_nr_first_grace_weeks = match opt_rewards_nr_first_grace_weeks {
-            OptionalValue::Some(nr) => nr,
-            OptionalValue::None => 0,
-        };
-        self.rewards_nr_first_grace_weeks()
-            .set_if_empty(rewards_nr_first_grace_weeks);
 
         let first_week_start_epoch = match opt_first_week_start_epoch {
             OptionalValue::Some(epoch) => epoch,

--- a/metabonding/src/rewards.rs
+++ b/metabonding/src/rewards.rs
@@ -4,6 +4,7 @@ multiversx_sc::derive_imports!();
 use crate::{
     claim::ClaimArgsWrapper,
     project::{Project, ProjectId},
+    validation::Signature,
 };
 
 pub type Week = usize;
@@ -119,6 +120,7 @@ pub trait RewardsModule:
             user_delegation_amount,
             user_lkmex_staked_amount,
             checkpoint,
+            signature: Signature::default(),
         };
 
         let mut rewards_pretty = MultiValueEncoded::new();

--- a/metabonding/src/validation.rs
+++ b/metabonding/src/validation.rs
@@ -1,8 +1,8 @@
 multiversx_sc::imports!();
 
 use crate::{
-    claim::{ClaimArgArray, SignedClaimArgArray, SignedClaimArgs},
-    claim_progress::{ClaimProgressGraceWeeks, ClaimProgressTracker, ShiftingClaimProgress},
+    claim::{ClaimArgArray, ClaimArgsWrapper},
+    claim_progress::{ClaimProgressTracker, ShiftingClaimProgress},
     rewards::{Week, FIRST_WEEK},
 };
 use multiversx_sc::api::ED25519_SIGNATURE_BYTE_LEN;
@@ -18,26 +18,18 @@ pub static INVALID_WEEK_NR_ERR_MSG: &[u8] = b"Invalid week number";
 
 #[multiversx_sc::module]
 pub trait ValidationModule: crate::common_storage::CommonStorageModule {
-    fn verify_signature(
-        &self,
-        caller: &ManagedAddress,
-        signed_claim_arg: &SignedClaimArgs<Self::Api>,
-    ) {
-        let week = signed_claim_arg.args_wrapper.week;
-        let user_delegation_amount = &signed_claim_arg.args_wrapper.user_delegation_amount;
-        let user_lkmex_staked_amount = &signed_claim_arg.args_wrapper.user_lkmex_staked_amount;
-
+    fn verify_signature(&self, caller: &ManagedAddress, claim_arg: &ClaimArgsWrapper<Self::Api>) {
         let mut data = ManagedBuffer::new();
-        let _ = week.dep_encode(&mut data);
+        let _ = claim_arg.week.dep_encode(&mut data);
         data.append(caller.as_managed_buffer());
-        let _ = user_delegation_amount.dep_encode(&mut data);
-        let _ = user_lkmex_staked_amount.dep_encode(&mut data);
+        let _ = claim_arg.user_delegation_amount.dep_encode(&mut data);
+        let _ = claim_arg.user_lkmex_staked_amount.dep_encode(&mut data);
 
         let signer = self.signer().get();
         let valid_signature = self.crypto().verify_ed25519_legacy_managed::<MAX_DATA_LEN>(
             signer.as_managed_byte_array(),
             &data,
-            &signed_claim_arg.signature,
+            &claim_arg.signature,
         );
         require!(valid_signature, "Invalid signature");
     }
@@ -45,57 +37,41 @@ pub trait ValidationModule: crate::common_storage::CommonStorageModule {
     fn validate_claim_args(
         &self,
         caller: &ManagedAddress,
-        signed_args: SignedClaimArgArray<Self::Api>,
-        grace_weeks_progress: &ClaimProgressGraceWeeks<Self::Api>,
-        shifting_progress: &ShiftingClaimProgress,
-        last_checkpoint_week: Week,
-    ) -> ClaimArgArray<Self::Api> {
-        let mut validated_args = ArrayVec::new();
-        for signed_claim_arg in signed_args {
-            self.validate_single_signed_claim_arg(
-                caller,
-                &signed_claim_arg,
-                grace_weeks_progress,
-                shifting_progress,
-                last_checkpoint_week,
-            );
-
-            unsafe {
-                validated_args.push_unchecked(signed_claim_arg.args_wrapper);
-            }
-        }
-
-        validated_args
-    }
-
-    fn validate_single_signed_claim_arg(
-        &self,
-        caller: &ManagedAddress,
-        signed_claim_arg: &SignedClaimArgs<Self::Api>,
-        grace_weeks_progress: &ClaimProgressGraceWeeks<Self::Api>,
+        claim_args: &ClaimArgArray<Self::Api>,
         shifting_progress: &ShiftingClaimProgress,
         last_checkpoint_week: Week,
     ) {
-        let claim_week = signed_claim_arg.args_wrapper.week;
+        for claim_arg in claim_args {
+            self.validate_single_claim_arg(
+                caller,
+                claim_arg,
+                shifting_progress,
+                last_checkpoint_week,
+            );
+        }
+    }
+
+    fn validate_single_claim_arg(
+        &self,
+        caller: &ManagedAddress,
+        claim_arg: &ClaimArgsWrapper<Self::Api>,
+        claim_progress: &ShiftingClaimProgress,
+        last_checkpoint_week: Week,
+    ) {
+        let claim_week = claim_arg.week;
         require!(
             claim_week >= FIRST_WEEK && claim_week <= last_checkpoint_week,
             INVALID_WEEK_NR_ERR_MSG
         );
-
-        let is_valid_grace_week = grace_weeks_progress.is_week_valid(claim_week);
-        let is_valid_shifting_week = shifting_progress.is_week_valid(claim_week);
         require!(
-            is_valid_grace_week || is_valid_shifting_week,
+            claim_progress.is_week_valid(claim_week),
             INVALID_WEEK_NR_ERR_MSG
         );
-
-        let can_claim_grace = grace_weeks_progress.can_claim_for_week(claim_week);
-        let can_claim_shifting = shifting_progress.can_claim_for_week(claim_week);
         require!(
-            can_claim_grace || can_claim_shifting,
+            claim_progress.can_claim_for_week(claim_week),
             ALREADY_CLAIMED_ERR_MSG
         );
 
-        self.verify_signature(caller, signed_claim_arg);
+        self.verify_signature(caller, claim_arg);
     }
 }

--- a/metabonding/tests/claim_progress_test.rs
+++ b/metabonding/tests/claim_progress_test.rs
@@ -1,10 +1,10 @@
 pub mod metabonding_setup;
 
-use multiversx_sc::types::{ManagedVec, MultiValueEncoded};
+use multiversx_sc::types::MultiValueEncoded;
 use multiversx_sc_scenario::{managed_address, rust_biguint};
 
 use metabonding::{
-    claim_progress::{ClaimProgressGraceWeeks, ClaimProgressModule, ShiftingClaimProgress},
+    claim_progress::{ClaimProgressModule, ShiftingClaimProgress},
     legacy_storage_cleanup::LegacyStorageCleanupModule,
 };
 use metabonding_setup::*;
@@ -28,36 +28,15 @@ fn claim_progress_migration_test() {
                 sc.legacy_rewards_claimed_flag(&managed_address!(&first_user), 5)
                     .set(true);
 
-                let grace_progress =
-                    sc.get_grace_weeks_progress(&managed_address!(&first_user), 5, 5);
-                let mut expected_grace_flags = ManagedVec::new();
-                expected_grace_flags.push(false); // index 0 unused, always false
-                expected_grace_flags.push(true);
-                expected_grace_flags.push(true);
-                expected_grace_flags.push(false);
-                expected_grace_flags.push(false);
-                expected_grace_flags.push(true);
-
-                let expected_grace_progress = ClaimProgressGraceWeeks::new(expected_grace_flags);
-                assert_eq!(grace_progress, expected_grace_progress);
-
-                // check grace progress after grace period passed. Should be empty
-                let grace_progress =
-                    sc.get_grace_weeks_progress(&managed_address!(&first_user), 5, 6);
-                assert_eq!(
-                    grace_progress,
-                    ClaimProgressGraceWeeks::new(ManagedVec::new())
-                );
-
                 // check shifting progress
-                let shifting_progress = sc.get_shifting_progress(&managed_address!(&first_user), 5);
+                let shifting_progress = sc.get_claim_progress(&managed_address!(&first_user), 5);
                 let expected_shifting_progress =
                     ShiftingClaimProgress::new([true, true, false, false, true], 5);
                 assert_eq!(shifting_progress, expected_shifting_progress);
 
                 // check shifted by 1
                 let shifting_progress_after_1 =
-                    sc.get_shifting_progress(&managed_address!(&first_user), 6);
+                    sc.get_claim_progress(&managed_address!(&first_user), 6);
                 let expected_shifting_progress_after_1 =
                     ShiftingClaimProgress::new([true, false, false, true, false], 6);
                 assert_eq!(
@@ -66,10 +45,9 @@ fn claim_progress_migration_test() {
                 );
 
                 // check shifted when getting from storage
-                sc.shifting_claim_progress(&managed_address!(&first_user))
+                sc.claim_progress(&managed_address!(&first_user))
                     .set(&shifting_progress);
-                let shifted_from_storage =
-                    sc.get_shifting_progress(&managed_address!(&first_user), 6);
+                let shifted_from_storage = sc.get_claim_progress(&managed_address!(&first_user), 6);
                 assert_eq!(shifted_from_storage, expected_shifting_progress_after_1);
             },
         )
@@ -91,7 +69,6 @@ fn claim_progress_cleanup_test() {
             &mb_setup.mb_wrapper,
             &rust_biguint!(0),
             |sc| {
-                sc.rewards_nr_first_grace_weeks().set(5);
                 sc.legacy_rewards_claimed_flag(&managed_address!(&first_user), 1)
                     .set(true);
                 sc.legacy_rewards_claimed_flag(&managed_address!(&first_user), 2)
@@ -103,24 +80,8 @@ fn claim_progress_cleanup_test() {
                 args.push(managed_address!(&first_user));
                 sc.clear_old_storage_flags(args);
 
-                let grace_progress = sc
-                    .claim_progress_grace_weeks(&managed_address!(&first_user))
-                    .get();
-                let mut expected_grace_flags = ManagedVec::new();
-                expected_grace_flags.push(false); // index 0 unused, always false
-                expected_grace_flags.push(true);
-                expected_grace_flags.push(true);
-                expected_grace_flags.push(false);
-                expected_grace_flags.push(false);
-                expected_grace_flags.push(true);
-
-                let expected_grace_progress = ClaimProgressGraceWeeks::new(expected_grace_flags);
-                assert_eq!(grace_progress, expected_grace_progress);
-
                 // check shifting progress
-                let shifting_progress = sc
-                    .shifting_claim_progress(&managed_address!(&first_user))
-                    .get();
+                let shifting_progress = sc.claim_progress(&managed_address!(&first_user)).get();
                 let expected_shifting_progress =
                     ShiftingClaimProgress::new([true, true, false, false, true], 5);
                 assert_eq!(shifting_progress, expected_shifting_progress);

--- a/metabonding/tests/metabonding_setup/mod.rs
+++ b/metabonding/tests/metabonding_setup/mod.rs
@@ -1,21 +1,21 @@
-use multiversx_sc::{
-    api::ED25519_SIGNATURE_BYTE_LEN,
-    codec::multi_types::OptionalValue,
-    types::{Address, MultiValueEncoded},
-};
-use multiversx_sc_scenario::{
-    managed_address, managed_biguint, managed_buffer, managed_token_id, rust_biguint,
-    whitebox::{BlockchainStateWrapper, ContractObjWrapper},
-    whitebox::TxResult,
-    DebugApi,
-};
-use multiversx_sc_modules::pause::PauseModule;
 use metabonding::rewards::RewardsModule;
 use metabonding::*;
 use metabonding::{claim::ClaimModule, project::ProjectModule};
 use metabonding::{
     common_storage::{CommonStorageModule, EPOCHS_IN_WEEK},
     rewards::Week,
+};
+use multiversx_sc::{
+    api::ED25519_SIGNATURE_BYTE_LEN,
+    codec::multi_types::OptionalValue,
+    types::{Address, MultiValueEncoded},
+};
+use multiversx_sc_modules::pause::PauseModule;
+use multiversx_sc_scenario::{
+    managed_address, managed_biguint, managed_buffer, managed_token_id, rust_biguint,
+    whitebox::TxResult,
+    whitebox::{BlockchainStateWrapper, ContractObjWrapper},
+    DebugApi,
 };
 
 // associated private key - used for generating the signatures (please don't steal my funds)
@@ -90,11 +90,7 @@ where
         b_mock
             .execute_tx(&owner_addr, &mb_wrapper, &rust_zero, |sc| {
                 let signer_addr = managed_address!(&Address::from(&SIGNER_ADDRESS));
-                sc.init(
-                    signer_addr.clone(),
-                    OptionalValue::None,
-                    OptionalValue::None,
-                );
+                sc.init(signer_addr.clone(), OptionalValue::None);
 
                 assert_eq!(sc.first_week_start_epoch().get(), 5);
                 assert_eq!(sc.signer().get(), signer_addr);

--- a/metabonding/tests/rust_tests.rs
+++ b/metabonding/tests/rust_tests.rs
@@ -1,6 +1,5 @@
 pub mod metabonding_setup;
 
-use metabonding::claim_progress::ClaimProgressModule;
 use metabonding_setup::*;
 use multiversx_sc_scenario::rust_biguint;
 
@@ -316,60 +315,6 @@ fn claim_rewards_multiple_test() {
     mb_setup
         .call_claim_rewards(&first_user_addr, 2, 25_000, 0, &sig_first_user_week_1)
         .assert_user_error("Already claimed rewards for this week");
-}
-
-#[test]
-fn grace_period_test() {
-    let mut mb_setup = MetabondingSetup::new(metabonding::contract_obj);
-    mb_setup.add_default_projects();
-    mb_setup.deposit_rewards_default_projects();
-    mb_setup.add_default_checkpoints();
-    mb_setup.call_unpause().assert_ok();
-
-    let owner_addr = mb_setup.owner_addr.clone();
-    let first_user_addr = mb_setup.first_user_addr.clone();
-    let sig_first_user_week_1 = hex_literal::hex!("d47c0d67b2d25de8b4a3f43d91a2b5ccb522afac47321ae80bf89c90a4445b26adefa693ab685fa20891f736d74eb2dedc11c4b1a8d6e642fa28df270d6ebe08");
-
-    // set current week = 6
-    mb_setup.b_mock.set_block_epoch(50);
-
-    // get claimable weeks - only able to claim week 2
-    let claimable_weeks = mb_setup.get_user_claimable_weeks(&first_user_addr);
-    assert_eq!(claimable_weeks, &[2usize]);
-
-    // set grace period of 5 weeks,
-    mb_setup
-        .b_mock
-        .execute_tx(&owner_addr, &mb_setup.mb_wrapper, &rust_biguint!(0), |sc| {
-            sc.rewards_nr_first_grace_weeks().set(5);
-        })
-        .assert_ok();
-
-    // get claimable weeks - user still can only claim for week 2
-    let claimable_weeks = mb_setup.get_user_claimable_weeks(&first_user_addr);
-    assert_eq!(claimable_weeks, &[2usize]);
-
-    // user try claim week 1
-    mb_setup
-        .call_claim_rewards(&first_user_addr, 1, 25_000, 0, &sig_first_user_week_1)
-        .assert_user_error("Invalid week number");
-
-    // set grace weeks to 6
-    mb_setup
-        .b_mock
-        .execute_tx(&owner_addr, &mb_setup.mb_wrapper, &rust_biguint!(0), |sc| {
-            sc.rewards_nr_first_grace_weeks().set(6);
-        })
-        .assert_ok();
-
-    // get claimable weeks - user can now claim for week 1 and 2
-    let claimable_weeks = mb_setup.get_user_claimable_weeks(&first_user_addr);
-    assert_eq!(claimable_weeks, &[1usize, 2usize]);
-
-    // user claim week 1 ok
-    mb_setup
-        .call_claim_rewards(&first_user_addr, 1, 25_000, 0, &sig_first_user_week_1)
-        .assert_ok();
 }
 
 #[test]


### PR DESCRIPTION
Not needed anymore, it was a one-time fix, and we don't need the overhead from it anymore.

Additionally, made `ClaimArgsWrapper` also contain the signature, instead of having a separate `Signed*` struct.