### PR TITLE
Select tokens on claim

### DIFF
--- a/metabonding/Cargo.toml
+++ b/metabonding/Cargo.toml
@@ -15,7 +15,7 @@ version = "=0.39.4"
 
 [dependencies.sc_whitelist_module]
 git = "https://github.com/multiversx/mx-exchange-sc"
-rev = "fdb1fb4"
+rev = "4941cae"
 
 [dev-dependencies]
 num-bigint = "0.4.2"

--- a/metabonding/src/claim.rs
+++ b/metabonding/src/claim.rs
@@ -19,7 +19,7 @@ pub type ClaimArgPair<M> = MultiValue4<Week, BigUint<M>, BigUint<M>, Signature<M
 pub type ClaimArgArray<M> = ArrayVec<ClaimArgsWrapper<M>, MAX_CLAIM_ARG_PAIRS>;
 pub type FlagsArray<M> = ArrayVec<ClaimFlag<M>, MAX_CLAIM_ARG_PAIRS>;
 
-#[derive(TypeAbi, TopEncode)]
+#[derive(TypeAbi, TopEncode, TopDecode)]
 pub enum ClaimableTokens<M: ManagedTypeApi> {
     All,
     Partial { unclaimed_projects: ProjIdsVec<M> },

--- a/metabonding/src/claim.rs
+++ b/metabonding/src/claim.rs
@@ -117,8 +117,8 @@ pub trait ClaimModule:
             current_week,
             &args,
             &mut claim_progress,
-            &projects_to_claim,
-            &all_projects,
+            projects_to_claim,
+            all_projects,
         );
         self.claim_progress(&original_caller).set(claim_progress);
 

--- a/metabonding/src/claim.rs
+++ b/metabonding/src/claim.rs
@@ -1,19 +1,29 @@
 multiversx_sc::imports!();
+multiversx_sc::derive_imports!();
 
 use multiversx_sc_modules::transfer_role_proxy::PaymentsVec;
 
 use crate::{
-    claim_progress::{ClaimProgressTracker, ShiftingClaimProgress},
-    project::{Project, ProjectId},
+    claim_progress::{ClaimFlag, ClaimProgressTracker, ShiftingClaimProgress},
+    project::{ProjIdsVec, Project, ProjectId},
     rewards::{RewardsCheckpoint, Week},
-    validation::{Signature, ALREADY_CLAIMED_ERR_MSG},
+    validation::Signature,
 };
+
+pub static NO_CLAIM_ARGS_ERR_MSG: &[u8] = b"No claim args";
 
 const MAX_CLAIM_ARG_PAIRS: usize = 5;
 const CLAIM_NR_ARGS_PER_PAIR: usize = 4;
 
 pub type ClaimArgPair<M> = MultiValue4<Week, BigUint<M>, BigUint<M>, Signature<M>>;
 pub type ClaimArgArray<M> = ArrayVec<ClaimArgsWrapper<M>, MAX_CLAIM_ARG_PAIRS>;
+pub type FlagsArray<M> = ArrayVec<ClaimFlag<M>, MAX_CLAIM_ARG_PAIRS>;
+
+#[derive(TypeAbi, TopEncode)]
+pub enum ClaimableTokens<M: ManagedTypeApi> {
+    All,
+    Partial { unclaimed_projects: ProjIdsVec<M> },
+}
 
 pub struct ClaimArgsWrapper<M: ManagedTypeApi> {
     pub week: Week,
@@ -62,7 +72,8 @@ pub trait ClaimModule:
         let mut claim_progress = self.get_claim_progress(&original_caller, current_week);
 
         let last_checkpoint_week = self.get_last_checkpoint_week();
-        let args = self.collect_claim_args(raw_claim_args);
+        let mut args = self.collect_claim_args(raw_claim_args);
+        self.sort_claim_args(&mut args);
         self.validate_claim_args(
             &original_caller,
             &args,
@@ -70,7 +81,14 @@ pub trait ClaimModule:
             last_checkpoint_week,
         );
 
-        let rewards = self.claim_all_project_rewards(current_week, &args, &mut claim_progress);
+        let all_projects = self.get_all_project_ids();
+        let rewards = self.claim_all_project_rewards(
+            current_week,
+            &args,
+            &mut claim_progress,
+            &all_projects,
+            &all_projects,
+        );
         self.claim_progress(&original_caller).set(claim_progress);
 
         if !rewards.is_empty() {
@@ -80,10 +98,15 @@ pub trait ClaimModule:
         rewards
     }
 
+    fn sort_claim_args(&self, claim_args: &mut ClaimArgArray<Self::Api>) {
+        claim_args.sort_unstable_by(|a, b| a.week.cmp(&b.week));
+    }
+
     fn collect_claim_args(
         &self,
         raw_claim_args: MultiValueEncoded<ClaimArgPair<Self::Api>>,
     ) -> ClaimArgArray<Self::Api> {
+        require!(!raw_claim_args.is_empty(), NO_CLAIM_ARGS_ERR_MSG);
         require!(
             raw_claim_args.raw_len() / CLAIM_NR_ARGS_PER_PAIR <= MAX_CLAIM_ARG_PAIRS,
             "Too many arguments"
@@ -117,24 +140,31 @@ pub trait ClaimModule:
         &self,
         current_week: Week,
         claim_args: &ClaimArgArray<Self::Api>,
-        claim_progress: &mut ShiftingClaimProgress,
+        claim_progress: &mut ShiftingClaimProgress<Self::Api>,
+        projects_to_claim: &ProjIdsVec<Self::Api>,
+        all_projects: &ProjIdsVec<Self::Api>,
     ) -> PaymentsVec<Self::Api> {
-        let mut all_rewards = PaymentsVec::new();
-        for (id, project) in self.projects().iter() {
-            let opt_rewards = self.claim_for_project(current_week, &id, project, claim_args);
-            if let Some(rewards) = opt_rewards {
-                all_rewards.push(rewards);
+        for arg in claim_args {
+            let flags_for_week = claim_progress.get_claim_flags_for_week(arg.week);
+            if matches!(flags_for_week, ClaimFlag::NotClaimed) {
+                claim_progress.set_claimed_for_week(arg.week, all_projects.clone())
             }
         }
 
-        for arg in claim_args {
-            // have to check again to prevent duplicate claims
-            require!(
-                claim_progress.can_claim_for_week(arg.week),
-                ALREADY_CLAIMED_ERR_MSG
-            );
+        let mut all_rewards = PaymentsVec::new();
+        let projects_mapper = self.projects();
+        for id in projects_to_claim {
+            let opt_project = projects_mapper.get(&id);
+            if opt_project.is_none() {
+                continue;
+            }
 
-            claim_progress.set_claimed_for_week(arg.week);
+            let project = unsafe { opt_project.unwrap_unchecked() };
+            let opt_rewards =
+                self.claim_for_project(current_week, &id, project, claim_args, claim_progress);
+            if let Some(rewards) = opt_rewards {
+                all_rewards.push(rewards);
+            }
         }
 
         all_rewards
@@ -146,14 +176,25 @@ pub trait ClaimModule:
         project_id: &ProjectId<Self::Api>,
         project: Project<Self::Api>,
         claim_args: &ClaimArgArray<Self::Api>,
+        claim_progress: &mut ShiftingClaimProgress<Self::Api>,
     ) -> Option<EsdtTokenPayment> {
         let mut rewards_for_project = BigUint::zero();
         for arg in claim_args {
+            let flags_mut = claim_progress.get_mut_claim_flags_for_week(arg.week);
+            let unclaimed_proj_ref = flags_mut.get_mut_unclaimed_proj();
+            let opt_index = unclaimed_proj_ref.find(project_id);
+            if opt_index.is_none() {
+                continue;
+            }
+
             let opt_weekly_reward =
                 self.get_weekly_reward_for_project(project_id, &project, current_week, arg);
             if let Some(weekly_reward) = opt_weekly_reward {
                 rewards_for_project += weekly_reward;
             }
+
+            let proj_index = unsafe { opt_index.unwrap_unchecked() };
+            unclaimed_proj_ref.remove(proj_index);
         }
 
         if rewards_for_project == 0 {
@@ -168,27 +209,37 @@ pub trait ClaimModule:
     }
 
     #[view(getUserClaimableWeeks)]
-    fn get_user_claimable_weeks(&self, user: ManagedAddress) -> MultiValueEncoded<Week> {
+    fn get_user_claimable_weeks(
+        &self,
+        user: ManagedAddress,
+    ) -> MultiValueEncoded<MultiValue2<Week, ClaimableTokens<Self::Api>>> {
         let current_week = self.get_current_week();
         let last_checkpoint_week = self.get_last_checkpoint_week();
         if current_week == 0 || last_checkpoint_week == 0 {
             return MultiValueEncoded::new();
         }
 
-        self.get_claimable_shifting_weeks(&user, current_week)
-            .into()
-    }
-
-    fn get_claimable_shifting_weeks(
-        &self,
-        user: &ManagedAddress,
-        current_week: Week,
-    ) -> ManagedVec<Week> {
-        let claim_progress = self.get_claim_progress(user, current_week);
+        let claim_progress = self.get_claim_progress(&user, current_week);
         let start_week =
-            ShiftingClaimProgress::get_first_index_week_for_new_current_week(current_week);
+            ShiftingClaimProgress::<Self::Api>::get_first_index_week_for_new_current_week(
+                current_week,
+            );
         let last_checkpoint_week = self.get_last_checkpoint_week();
 
-        self.get_claimable_weeks(&claim_progress, start_week, last_checkpoint_week)
+        let mut claimable_weeks = MultiValueEncoded::new();
+        for week in start_week..=last_checkpoint_week {
+            let claim_flags = claim_progress.get_claim_flags_for_week(week);
+            match claim_flags {
+                ClaimFlag::NotClaimed => claimable_weeks.push((week, ClaimableTokens::All).into()),
+                ClaimFlag::Claimed { unclaimed_projects } => {
+                    let partial = ClaimableTokens::Partial {
+                        unclaimed_projects: unclaimed_projects.clone(),
+                    };
+                    claimable_weeks.push((week, partial).into());
+                }
+            };
+        }
+
+        claimable_weeks
     }
 }

--- a/metabonding/src/claim_progress.rs
+++ b/metabonding/src/claim_progress.rs
@@ -2,34 +2,64 @@ multiversx_sc::imports!();
 multiversx_sc::derive_imports!();
 
 use crate::{
-    project::PROJECT_EXPIRATION_WEEKS,
+    project::{ProjIdsVec, PROJECT_EXPIRATION_WEEKS},
     rewards::{Week, FIRST_WEEK},
+    validation::INVALID_WEEK_NR_ERR_MSG,
 };
 
-type ClaimFlag = bool;
-const CLAIMED: ClaimFlag = true;
-const NOT_CLAIMED: ClaimFlag = false;
+#[derive(TypeAbi, TopEncode, TopDecode, NestedEncode, NestedDecode, Clone, PartialEq, Debug)]
+pub enum ClaimFlag<M: ManagedTypeApi> {
+    NotClaimed,
+    Claimed { unclaimed_projects: ProjIdsVec<M> },
+}
+
+impl<M: ManagedTypeApi> ClaimFlag<M> {
+    pub fn from_old_flag(old_flag: bool) -> Self {
+        if old_flag {
+            ClaimFlag::Claimed {
+                unclaimed_projects: ManagedVec::new(),
+            }
+        } else {
+            ClaimFlag::NotClaimed
+        }
+    }
+
+    pub fn get_mut_unclaimed_proj(&mut self) -> &mut ProjIdsVec<M> {
+        match self {
+            ClaimFlag::NotClaimed => M::error_api_impl().signal_error(b"Invalid flags state"),
+            ClaimFlag::Claimed { unclaimed_projects } => unclaimed_projects,
+        }
+    }
+}
 
 const CLAIM_FLAGS_LEN: usize = PROJECT_EXPIRATION_WEEKS + 1;
-type ClaimFlagsArray = [ClaimFlag; CLAIM_FLAGS_LEN];
-const DEFAULT_CLAIM_FLAGS: ClaimFlagsArray = [NOT_CLAIMED; CLAIM_FLAGS_LEN];
+type ClaimFlagsArray<M> = ArrayVec<ClaimFlag<M>, CLAIM_FLAGS_LEN>;
 
-pub trait ClaimProgressTracker {
+fn default_claim_flags<M: ManagedTypeApi>() -> ClaimFlagsArray<M> {
+    let mut array = ArrayVec::new();
+    array.fill(ClaimFlag::NotClaimed);
+
+    array
+}
+
+pub trait ClaimProgressTracker<M: ManagedTypeApi> {
     fn is_week_valid(&self, week: Week) -> bool;
 
-    fn can_claim_for_week(&self, week: Week) -> bool;
+    fn get_claim_flags_for_week(&self, week: Week) -> &ClaimFlag<M>;
 
-    fn set_claimed_for_week(&mut self, week: Week);
+    fn get_mut_claim_flags_for_week(&mut self, week: Week) -> &mut ClaimFlag<M>;
+
+    fn set_claimed_for_week(&mut self, week: Week, unclaimed_projects: ProjIdsVec<M>);
 }
 
 #[derive(TypeAbi, TopEncode, TopDecode, PartialEq, Debug)]
-pub struct ShiftingClaimProgress {
-    claim_flags: ClaimFlagsArray,
+pub struct ShiftingClaimProgress<M: ManagedTypeApi> {
+    claim_flags: ClaimFlagsArray<M>,
     first_index_week: Week,
 }
 
-impl ShiftingClaimProgress {
-    pub fn new(claim_flags: ClaimFlagsArray, current_week: Week) -> Self {
+impl<M: ManagedTypeApi> ShiftingClaimProgress<M> {
+    pub fn new(claim_flags: ClaimFlagsArray<M>, current_week: Week) -> Self {
         Self {
             claim_flags,
             first_index_week: Self::get_first_index_week_for_new_current_week(current_week),
@@ -62,68 +92,61 @@ impl ShiftingClaimProgress {
         let nr_shifts = new_first_week - self.first_index_week;
         if nr_shifts < CLAIM_FLAGS_LEN {
             // shift to the left by nr_shifts
-            self.claim_flags.copy_within(nr_shifts..CLAIM_FLAGS_LEN, 0);
+            let _ = self.claim_flags.drain(0..nr_shifts);
 
             let new_pos_first_index = CLAIM_FLAGS_LEN - nr_shifts;
             for i in new_pos_first_index..CLAIM_FLAGS_LEN {
-                self.claim_flags[i] = NOT_CLAIMED;
+                self.claim_flags[i] = ClaimFlag::NotClaimed;
             }
         } else {
-            self.claim_flags = DEFAULT_CLAIM_FLAGS;
+            self.claim_flags = default_claim_flags();
         }
 
         self.first_index_week = new_first_week;
     }
 }
 
-impl ClaimProgressTracker for ShiftingClaimProgress {
+impl<M: ManagedTypeApi> ClaimProgressTracker<M> for ShiftingClaimProgress<M> {
     fn is_week_valid(&self, week: Week) -> bool {
         let last_index = self.first_index_week + CLAIM_FLAGS_LEN - 1;
         week >= self.first_index_week && week <= last_index
     }
 
-    fn can_claim_for_week(&self, week: Week) -> bool {
+    fn get_claim_flags_for_week(&self, week: Week) -> &ClaimFlag<M> {
         if !self.is_week_valid(week) {
-            return false;
+            M::error_api_impl().signal_error(INVALID_WEEK_NR_ERR_MSG);
         }
 
         let index = self.get_index_for_week(week);
-        !self.claim_flags[index]
+        &self.claim_flags[index]
     }
 
-    fn set_claimed_for_week(&mut self, week: Week) {
+    fn get_mut_claim_flags_for_week(&mut self, week: Week) -> &mut ClaimFlag<M> {
+        if !self.is_week_valid(week) {
+            M::error_api_impl().signal_error(INVALID_WEEK_NR_ERR_MSG);
+        }
+
+        let index = self.get_index_for_week(week);
+        &mut self.claim_flags[index]
+    }
+
+    fn set_claimed_for_week(&mut self, week: Week, unclaimed_projects: ProjIdsVec<M>) {
         if !self.is_week_valid(week) {
             return;
         }
 
         let index = self.get_index_for_week(week);
-        self.claim_flags[index] = CLAIMED;
+        self.claim_flags[index] = ClaimFlag::Claimed { unclaimed_projects };
     }
 }
 
 #[multiversx_sc::module]
 pub trait ClaimProgressModule {
-    fn get_claimable_weeks<CPT: ClaimProgressTracker>(
-        &self,
-        tracker: &CPT,
-        start_week: Week,
-        end_week: Week,
-    ) -> ManagedVec<Week> {
-        let mut claimable_weeks = ManagedVec::new();
-        for week in start_week..=end_week {
-            if tracker.can_claim_for_week(week) {
-                claimable_weeks.push(week);
-            }
-        }
-
-        claimable_weeks
-    }
-
     fn get_claim_progress(
         &self,
         user: &ManagedAddress,
         current_week: Week,
-    ) -> ShiftingClaimProgress {
+    ) -> ShiftingClaimProgress<Self::Api> {
         let mapper = self.claim_progress(user);
         if !mapper.is_empty() {
             let mut existing_progress = mapper.get();
@@ -132,19 +155,24 @@ pub trait ClaimProgressModule {
             return existing_progress;
         }
 
-        let mut claim_flags = DEFAULT_CLAIM_FLAGS;
+        let mut claim_flags = default_claim_flags();
         let first_accepted_week =
-            ShiftingClaimProgress::get_first_index_week_for_new_current_week(current_week);
+            ShiftingClaimProgress::<Self::Api>::get_first_index_week_for_new_current_week(
+                current_week,
+            );
         for (i, week) in (first_accepted_week..=current_week).enumerate() {
             let old_flag = self.legacy_rewards_claimed_flag(user, week).get();
-            claim_flags[i] = old_flag;
+            claim_flags[i] = ClaimFlag::from_old_flag(old_flag);
         }
 
         ShiftingClaimProgress::new(claim_flags, current_week)
     }
 
     #[storage_mapper("claimProgress")]
-    fn claim_progress(&self, user: &ManagedAddress) -> SingleValueMapper<ShiftingClaimProgress>;
+    fn claim_progress(
+        &self,
+        user: &ManagedAddress,
+    ) -> SingleValueMapper<ShiftingClaimProgress<Self::Api>>;
 
     #[storage_mapper("rewardsClaimed")]
     fn legacy_rewards_claimed_flag(
@@ -160,56 +188,56 @@ mod claim_progress_tests {
 
     #[test]
     fn claim_progress_shift_test() {
-        let mut progress = ShiftingClaimProgress {
-            claim_flags: [true, false, true, true, false],
-            first_index_week: FIRST_WEEK,
-        };
+        // let mut progress = ShiftingClaimProgress {
+        //     claim_flags: [true, false, true, true, false],
+        //     first_index_week: FIRST_WEEK,
+        // };
 
-        // no shift needed
-        for i in FIRST_WEEK..=CLAIM_FLAGS_LEN {
-            progress.shift_if_needed(i);
-            assert!(
-                progress.claim_flags == [true, false, true, true, false]
-                    && progress.first_index_week == FIRST_WEEK
-            );
-        }
+        // // no shift needed
+        // for i in FIRST_WEEK..=CLAIM_FLAGS_LEN {
+        //     progress.shift_if_needed(i);
+        //     assert!(
+        //         progress.claim_flags == [true, false, true, true, false]
+        //             && progress.first_index_week == FIRST_WEEK
+        //     );
+        // }
 
-        // shift by 1
-        let mut expected_first_index_week = FIRST_WEEK + 1;
-        let mut current_week = CLAIM_FLAGS_LEN + 1;
-        progress.shift_if_needed(current_week);
-        assert!(
-            progress.claim_flags == [false, true, true, false, false]
-                && progress.first_index_week == expected_first_index_week
-        );
+        // // shift by 1
+        // let mut expected_first_index_week = FIRST_WEEK + 1;
+        // let mut current_week = CLAIM_FLAGS_LEN + 1;
+        // progress.shift_if_needed(current_week);
+        // assert!(
+        //     progress.claim_flags == [false, true, true, false, false]
+        //         && progress.first_index_week == expected_first_index_week
+        // );
 
-        // shift by 2
-        expected_first_index_week += 2;
-        current_week += 2;
-        progress.shift_if_needed(current_week);
-        assert!(
-            progress.claim_flags == [true, false, false, false, false]
-                && progress.first_index_week == expected_first_index_week
-        );
+        // // shift by 2
+        // expected_first_index_week += 2;
+        // current_week += 2;
+        // progress.shift_if_needed(current_week);
+        // assert!(
+        //     progress.claim_flags == [true, false, false, false, false]
+        //         && progress.first_index_week == expected_first_index_week
+        // );
 
-        // test full shift
-        progress.claim_flags = [true; CLAIM_FLAGS_LEN];
-        expected_first_index_week += CLAIM_FLAGS_LEN;
-        current_week += CLAIM_FLAGS_LEN;
-        progress.shift_if_needed(current_week);
-        assert!(
-            progress.claim_flags == [false; CLAIM_FLAGS_LEN]
-                && progress.first_index_week == expected_first_index_week
-        );
+        // // test full shift
+        // progress.claim_flags = [true; CLAIM_FLAGS_LEN];
+        // expected_first_index_week += CLAIM_FLAGS_LEN;
+        // current_week += CLAIM_FLAGS_LEN;
+        // progress.shift_if_needed(current_week);
+        // assert!(
+        //     progress.claim_flags == [false; CLAIM_FLAGS_LEN]
+        //         && progress.first_index_week == expected_first_index_week
+        // );
 
-        // shift all flags but 1
-        progress.claim_flags = [true; CLAIM_FLAGS_LEN];
-        expected_first_index_week += CLAIM_FLAGS_LEN - 1;
-        current_week += CLAIM_FLAGS_LEN - 1;
-        progress.shift_if_needed(current_week);
-        assert!(
-            progress.claim_flags == [true, false, false, false, false]
-                && progress.first_index_week == expected_first_index_week
-        );
+        // // shift all flags but 1
+        // progress.claim_flags = [true; CLAIM_FLAGS_LEN];
+        // expected_first_index_week += CLAIM_FLAGS_LEN - 1;
+        // current_week += CLAIM_FLAGS_LEN - 1;
+        // progress.shift_if_needed(current_week);
+        // assert!(
+        //     progress.claim_flags == [true, false, false, false, false]
+        //         && progress.first_index_week == expected_first_index_week
+        // );
     }
 }

--- a/metabonding/src/claim_progress.rs
+++ b/metabonding/src/claim_progress.rs
@@ -213,7 +213,7 @@ mod claim_progress_tests {
             progress.shift_if_needed(i);
             assert!(
                 progress.claim_flags.as_slice()
-                    == &[
+                    == [
                         claimed.clone(),
                         not_claimed.clone(),
                         claimed.clone(),
@@ -230,7 +230,7 @@ mod claim_progress_tests {
         progress.shift_if_needed(current_week);
         assert!(
             progress.claim_flags.as_slice()
-                == &[
+                == [
                     not_claimed.clone(),
                     claimed.clone(),
                     claimed.clone(),
@@ -246,7 +246,7 @@ mod claim_progress_tests {
         progress.shift_if_needed(current_week);
         assert!(
             progress.claim_flags.as_slice()
-                == &[
+                == [
                     claimed.clone(),
                     not_claimed.clone(),
                     not_claimed.clone(),
@@ -289,12 +289,12 @@ mod claim_progress_tests {
         progress.shift_if_needed(current_week);
         assert!(
             progress.claim_flags.as_slice()
-                == &[
-                    claimed.clone(),
+                == [
+                    claimed,
                     not_claimed.clone(),
                     not_claimed.clone(),
                     not_claimed.clone(),
-                    not_claimed.clone(),
+                    not_claimed,
                 ]
                 && progress.first_index_week == expected_first_index_week
         );

--- a/metabonding/src/claim_progress.rs
+++ b/metabonding/src/claim_progress.rs
@@ -37,7 +37,9 @@ type ClaimFlagsArray<M> = ArrayVec<ClaimFlag<M>, CLAIM_FLAGS_LEN>;
 
 fn default_claim_flags<M: ManagedTypeApi>() -> ClaimFlagsArray<M> {
     let mut array = ArrayVec::new();
-    array.fill(ClaimFlag::NotClaimed);
+    for _ in 0..CLAIM_FLAGS_LEN {
+        unsafe { array.push_unchecked(ClaimFlag::NotClaimed) };
+    }
 
     array
 }

--- a/metabonding/src/project.rs
+++ b/metabonding/src/project.rs
@@ -13,6 +13,7 @@ const MIN_GAS_FOR_CLEAR: u64 = 5_000_000;
 static INVALID_PROJECT_ID_ERR_MSG: &[u8] = b"Invalid project ID";
 
 pub type ProjectId<M> = ManagedBuffer<M>;
+pub type ProjIdsVec<M> = ManagedVec<M, ProjectId<M>>;
 pub type ProjectAsMultiResult<M> =
     MultiValue5<TokenIdentifier<M>, BigUint<M>, BigUint<M>, Week, Week>;
 pub type Epoch = u64;
@@ -171,13 +172,17 @@ pub trait ProjectModule: crate::common_storage::CommonStorageModule {
     }
 
     #[view(getAllProjectIds)]
-    fn get_all_project_ids(&self) -> MultiValueEncoded<ProjectId<Self::Api>> {
+    fn get_all_project_ids_view(&self) -> MultiValueEncoded<ProjectId<Self::Api>> {
+        self.get_all_project_ids().into()
+    }
+
+    fn get_all_project_ids(&self) -> ProjIdsVec<Self::Api> {
         let mut all_ids = ManagedVec::new();
         for id in self.projects().keys() {
             all_ids.push(id);
         }
 
-        all_ids.into()
+        all_ids
     }
 
     /// Returns a project by ID. The results are, in order:

--- a/metabonding/src/validation.rs
+++ b/metabonding/src/validation.rs
@@ -1,7 +1,7 @@
 multiversx_sc::imports!();
 
 use crate::{
-    claim::{ClaimArgArray, ClaimArgsWrapper},
+    claim::{ClaimArgArray, ClaimArgsWrapper, NO_CLAIM_ARGS_ERR_MSG},
     claim_progress::{ClaimProgressTracker, ShiftingClaimProgress},
     rewards::{Week, FIRST_WEEK},
 };
@@ -38,16 +38,26 @@ pub trait ValidationModule: crate::common_storage::CommonStorageModule {
         &self,
         caller: &ManagedAddress,
         claim_args: &ClaimArgArray<Self::Api>,
-        shifting_progress: &ShiftingClaimProgress,
+        claim_progress: &ShiftingClaimProgress<Self::Api>,
         last_checkpoint_week: Week,
     ) {
+        self.check_no_duplicate_claim_args(claim_args);
+
         for claim_arg in claim_args {
-            self.validate_single_claim_arg(
-                caller,
-                claim_arg,
-                shifting_progress,
-                last_checkpoint_week,
-            );
+            self.validate_single_claim_arg(caller, claim_arg, claim_progress, last_checkpoint_week);
+        }
+    }
+
+    fn check_no_duplicate_claim_args(&self, claim_args: &ClaimArgArray<Self::Api>) {
+        let mut iterator = claim_args.iter();
+        let opt_prev_elem = iterator.next();
+        require!(opt_prev_elem.is_some(), NO_CLAIM_ARGS_ERR_MSG);
+
+        let mut prev_elem = unsafe { opt_prev_elem.unwrap_unchecked() };
+        while let Some(current_elem) = iterator.next() {
+            require!(prev_elem.week != current_elem.week, "Duplicate claim args");
+
+            prev_elem = current_elem;
         }
     }
 
@@ -55,7 +65,7 @@ pub trait ValidationModule: crate::common_storage::CommonStorageModule {
         &self,
         caller: &ManagedAddress,
         claim_arg: &ClaimArgsWrapper<Self::Api>,
-        claim_progress: &ShiftingClaimProgress,
+        claim_progress: &ShiftingClaimProgress<Self::Api>,
         last_checkpoint_week: Week,
     ) {
         let claim_week = claim_arg.week;
@@ -66,10 +76,6 @@ pub trait ValidationModule: crate::common_storage::CommonStorageModule {
         require!(
             claim_progress.is_week_valid(claim_week),
             INVALID_WEEK_NR_ERR_MSG
-        );
-        require!(
-            claim_progress.can_claim_for_week(claim_week),
-            ALREADY_CLAIMED_ERR_MSG
         );
 
         self.verify_signature(caller, claim_arg);

--- a/metabonding/src/validation.rs
+++ b/metabonding/src/validation.rs
@@ -2,7 +2,7 @@ multiversx_sc::imports!();
 
 use crate::{
     claim::{ClaimArgArray, ClaimArgsWrapper, NO_CLAIM_ARGS_ERR_MSG},
-    claim_progress::{ClaimProgressTracker, ShiftingClaimProgress},
+    claim_progress::{ClaimFlag, ClaimProgressTracker, ShiftingClaimProgress},
     rewards::{Week, FIRST_WEEK},
 };
 use multiversx_sc::api::ED25519_SIGNATURE_BYTE_LEN;
@@ -77,6 +77,11 @@ pub trait ValidationModule: crate::common_storage::CommonStorageModule {
             claim_progress.is_week_valid(claim_week),
             INVALID_WEEK_NR_ERR_MSG
         );
+
+        let claim_flag = claim_progress.get_claim_flags_for_week(claim_week);
+        if let ClaimFlag::Claimed { unclaimed_projects } = claim_flag {
+            require!(!unclaimed_projects.is_empty(), ALREADY_CLAIMED_ERR_MSG);
+        }
 
         self.verify_signature(caller, claim_arg);
     }

--- a/metabonding/src/validation.rs
+++ b/metabonding/src/validation.rs
@@ -54,7 +54,7 @@ pub trait ValidationModule: crate::common_storage::CommonStorageModule {
         require!(opt_prev_elem.is_some(), NO_CLAIM_ARGS_ERR_MSG);
 
         let mut prev_elem = unsafe { opt_prev_elem.unwrap_unchecked() };
-        while let Some(current_elem) = iterator.next() {
+        for current_elem in iterator {
             require!(prev_elem.week != current_elem.week, "Duplicate claim args");
 
             prev_elem = current_elem;

--- a/metabonding/tests/claim_partial_test.rs
+++ b/metabonding/tests/claim_partial_test.rs
@@ -1,0 +1,265 @@
+pub mod metabonding_setup;
+
+use std::iter::FromIterator;
+
+use metabonding::claim_progress::{ClaimFlag, ClaimProgressModule, ShiftingClaimProgress};
+use metabonding_setup::*;
+use multiversx_sc::types::ManagedVec;
+use multiversx_sc_scenario::{managed_address, managed_buffer, rust_biguint};
+
+#[test]
+fn claim_partial_ok_test() {
+    let mut mb_setup = MetabondingSetup::new(metabonding::contract_obj);
+    mb_setup.add_default_projects();
+    mb_setup.deposit_rewards_default_projects();
+    mb_setup.add_default_checkpoints();
+    mb_setup.call_unpause().assert_ok();
+
+    let first_user_addr = mb_setup.first_user_addr.clone();
+    let sig_first_user_week_1 = hex_literal::hex!("d47c0d67b2d25de8b4a3f43d91a2b5ccb522afac47321ae80bf89c90a4445b26adefa693ab685fa20891f736d74eb2dedc11c4b1a8d6e642fa28df270d6ebe08");
+    let sig_first_user_week_2 = hex_literal::hex!("b4aadf08eea4cc7c636922511943edbab2ff6ef2558528e0e7b03c7448367989fe860ac091be4d942304f04c86b1eaa0501f36e02819a3c628b4c53f3d3ac801");
+
+    // claim only second token for week 2
+    mb_setup
+        .call_claim_partial_rewards(
+            &first_user_addr,
+            2,
+            25_000,
+            0,
+            &sig_first_user_week_2,
+            &[SECOND_PROJ_ID],
+        )
+        .assert_ok();
+
+    mb_setup
+        .b_mock
+        .check_esdt_balance(&first_user_addr, FIRST_PROJ_TOKEN, &rust_biguint!(0));
+    mb_setup.b_mock.check_esdt_balance(
+        &first_user_addr,
+        SECOND_PROJ_TOKEN,
+        &rust_biguint!(50_000_000),
+    );
+
+    mb_setup
+        .b_mock
+        .execute_query(&mb_setup.mb_wrapper, |sc| {
+            let not_claimed = ClaimFlag::NotClaimed;
+
+            // check shifting progress
+            let shifting_progress = sc.claim_progress(&managed_address!(&first_user_addr)).get();
+            let expected_shifting_progress = ShiftingClaimProgress::new(
+                [
+                    not_claimed.clone(),
+                    ClaimFlag::Claimed {
+                        unclaimed_projects: ManagedVec::from_single_item(managed_buffer!(
+                            FIRST_PROJ_ID
+                        )),
+                    },
+                    not_claimed.clone(),
+                    not_claimed.clone(),
+                    not_claimed.clone(),
+                ]
+                .into(),
+                2,
+            );
+            assert_eq!(shifting_progress, expected_shifting_progress);
+        })
+        .assert_ok();
+
+    // try claim second project for week 2 again - no rewards given, no state changes
+    mb_setup
+        .call_claim_partial_rewards(
+            &first_user_addr,
+            2,
+            25_000,
+            0,
+            &sig_first_user_week_2,
+            &[SECOND_PROJ_ID],
+        )
+        .assert_ok();
+
+    mb_setup
+        .b_mock
+        .check_esdt_balance(&first_user_addr, FIRST_PROJ_TOKEN, &rust_biguint!(0));
+    mb_setup.b_mock.check_esdt_balance(
+        &first_user_addr,
+        SECOND_PROJ_TOKEN,
+        &rust_biguint!(50_000_000),
+    );
+
+    mb_setup
+        .b_mock
+        .execute_query(&mb_setup.mb_wrapper, |sc| {
+            let not_claimed = ClaimFlag::NotClaimed;
+
+            // check shifting progress
+            let shifting_progress = sc.claim_progress(&managed_address!(&first_user_addr)).get();
+            let expected_shifting_progress = ShiftingClaimProgress::new(
+                [
+                    not_claimed.clone(),
+                    ClaimFlag::Claimed {
+                        unclaimed_projects: ManagedVec::from_single_item(managed_buffer!(
+                            FIRST_PROJ_ID
+                        )),
+                    },
+                    not_claimed.clone(),
+                    not_claimed.clone(),
+                    not_claimed.clone(),
+                ]
+                .into(),
+                2,
+            );
+            assert_eq!(shifting_progress, expected_shifting_progress);
+        })
+        .assert_ok();
+
+    // claim first proj for week 2
+    mb_setup
+        .call_claim_partial_rewards(
+            &first_user_addr,
+            2,
+            25_000,
+            0,
+            &sig_first_user_week_2,
+            &[FIRST_PROJ_ID],
+        )
+        .assert_ok();
+
+    mb_setup.b_mock.check_esdt_balance(
+        &first_user_addr,
+        FIRST_PROJ_TOKEN,
+        &rust_biguint!(41_666_666),
+    );
+    mb_setup.b_mock.check_esdt_balance(
+        &first_user_addr,
+        SECOND_PROJ_TOKEN,
+        &rust_biguint!(50_000_000),
+    );
+
+    mb_setup
+        .b_mock
+        .execute_query(&mb_setup.mb_wrapper, |sc| {
+            let not_claimed = ClaimFlag::NotClaimed;
+
+            // check shifting progress
+            let shifting_progress = sc.claim_progress(&managed_address!(&first_user_addr)).get();
+            let expected_shifting_progress = ShiftingClaimProgress::new(
+                [
+                    not_claimed.clone(),
+                    ClaimFlag::Claimed {
+                        unclaimed_projects: ManagedVec::new(),
+                    },
+                    not_claimed.clone(),
+                    not_claimed.clone(),
+                    not_claimed.clone(),
+                ]
+                .into(),
+                2,
+            );
+            assert_eq!(shifting_progress, expected_shifting_progress);
+        })
+        .assert_ok();
+
+    // try claim week 2 again - no tokens left
+    mb_setup
+        .call_claim_partial_rewards(
+            &first_user_addr,
+            2,
+            25_000,
+            0,
+            &sig_first_user_week_2,
+            &[FIRST_PROJ_ID, SECOND_PROJ_ID],
+        )
+        .assert_user_error("Already claimed rewards for this week");
+
+    // claim for first week with invalid project IDs
+    mb_setup
+        .call_claim_partial_rewards(
+            &first_user_addr,
+            1,
+            25_000,
+            0,
+            &sig_first_user_week_1,
+            &[b"SCAM-123456", b"BAD-123456"],
+        )
+        .assert_ok();
+
+    mb_setup
+        .b_mock
+        .execute_query(&mb_setup.mb_wrapper, |sc| {
+            let not_claimed = ClaimFlag::NotClaimed;
+
+            // check shifting progress
+            let shifting_progress = sc.claim_progress(&managed_address!(&first_user_addr)).get();
+            let expected_shifting_progress = ShiftingClaimProgress::new(
+                [
+                    ClaimFlag::Claimed {
+                        unclaimed_projects: ManagedVec::from_iter(vec![
+                            managed_buffer!(FIRST_PROJ_ID),
+                            managed_buffer!(SECOND_PROJ_ID),
+                        ]),
+                    },
+                    ClaimFlag::Claimed {
+                        unclaimed_projects: ManagedVec::new(),
+                    },
+                    not_claimed.clone(),
+                    not_claimed.clone(),
+                    not_claimed.clone(),
+                ]
+                .into(),
+                2,
+            );
+            assert_eq!(shifting_progress, expected_shifting_progress);
+        })
+        .assert_ok();
+
+    // claim all for week 1
+    mb_setup
+        .call_claim_partial_rewards(
+            &first_user_addr,
+            1,
+            25_000,
+            0,
+            &sig_first_user_week_1,
+            &[FIRST_PROJ_ID, SECOND_PROJ_ID],
+        )
+        .assert_ok();
+
+    // same result as if the user claimed full intially
+    mb_setup.b_mock.check_esdt_balance(
+        &first_user_addr,
+        FIRST_PROJ_TOKEN,
+        &rust_biguint!(83_333_333 + 41_666_666),
+    );
+    mb_setup.b_mock.check_esdt_balance(
+        &first_user_addr,
+        SECOND_PROJ_TOKEN,
+        &rust_biguint!(50_000_000),
+    );
+
+    mb_setup
+        .b_mock
+        .execute_query(&mb_setup.mb_wrapper, |sc| {
+            let not_claimed = ClaimFlag::NotClaimed;
+
+            // check shifting progress
+            let shifting_progress = sc.claim_progress(&managed_address!(&first_user_addr)).get();
+            let expected_shifting_progress = ShiftingClaimProgress::new(
+                [
+                    ClaimFlag::Claimed {
+                        unclaimed_projects: ManagedVec::new(),
+                    },
+                    ClaimFlag::Claimed {
+                        unclaimed_projects: ManagedVec::new(),
+                    },
+                    not_claimed.clone(),
+                    not_claimed.clone(),
+                    not_claimed.clone(),
+                ]
+                .into(),
+                2,
+            );
+            assert_eq!(shifting_progress, expected_shifting_progress);
+        })
+        .assert_ok();
+}

--- a/metabonding/tests/claim_partial_test.rs
+++ b/metabonding/tests/claim_partial_test.rs
@@ -57,7 +57,7 @@ fn claim_partial_ok_test() {
                     },
                     not_claimed.clone(),
                     not_claimed.clone(),
-                    not_claimed.clone(),
+                    not_claimed,
                 ]
                 .into(),
                 2,
@@ -104,7 +104,7 @@ fn claim_partial_ok_test() {
                     },
                     not_claimed.clone(),
                     not_claimed.clone(),
-                    not_claimed.clone(),
+                    not_claimed,
                 ]
                 .into(),
                 2,
@@ -151,7 +151,7 @@ fn claim_partial_ok_test() {
                     },
                     not_claimed.clone(),
                     not_claimed.clone(),
-                    not_claimed.clone(),
+                    not_claimed,
                 ]
                 .into(),
                 2,
@@ -204,7 +204,7 @@ fn claim_partial_ok_test() {
                     },
                     not_claimed.clone(),
                     not_claimed.clone(),
-                    not_claimed.clone(),
+                    not_claimed,
                 ]
                 .into(),
                 2,
@@ -254,7 +254,7 @@ fn claim_partial_ok_test() {
                     },
                     not_claimed.clone(),
                     not_claimed.clone(),
-                    not_claimed.clone(),
+                    not_claimed,
                 ]
                 .into(),
                 2,

--- a/metabonding/tests/claim_progress_test.rs
+++ b/metabonding/tests/claim_progress_test.rs
@@ -1,10 +1,10 @@
 pub mod metabonding_setup;
 
-use multiversx_sc::types::MultiValueEncoded;
+use multiversx_sc::types::{ManagedVec, MultiValueEncoded};
 use multiversx_sc_scenario::{managed_address, rust_biguint};
 
 use metabonding::{
-    claim_progress::{ClaimProgressModule, ShiftingClaimProgress},
+    claim_progress::{ClaimFlag, ClaimProgressModule, ShiftingClaimProgress},
     legacy_storage_cleanup::LegacyStorageCleanupModule,
 };
 use metabonding_setup::*;
@@ -28,17 +28,40 @@ fn claim_progress_migration_test() {
                 sc.legacy_rewards_claimed_flag(&managed_address!(&first_user), 5)
                     .set(true);
 
+                let not_claimed = ClaimFlag::NotClaimed;
+                let claimed = ClaimFlag::Claimed {
+                    unclaimed_projects: ManagedVec::new(),
+                };
+
                 // check shifting progress
                 let shifting_progress = sc.get_claim_progress(&managed_address!(&first_user), 5);
-                let expected_shifting_progress =
-                    ShiftingClaimProgress::new([true, true, false, false, true], 5);
+                let expected_shifting_progress = ShiftingClaimProgress::new(
+                    [
+                        claimed.clone(),
+                        claimed.clone(),
+                        not_claimed.clone(),
+                        not_claimed.clone(),
+                        claimed.clone(),
+                    ]
+                    .into(),
+                    5,
+                );
                 assert_eq!(shifting_progress, expected_shifting_progress);
 
                 // check shifted by 1
                 let shifting_progress_after_1 =
                     sc.get_claim_progress(&managed_address!(&first_user), 6);
-                let expected_shifting_progress_after_1 =
-                    ShiftingClaimProgress::new([true, false, false, true, false], 6);
+                let expected_shifting_progress_after_1 = ShiftingClaimProgress::new(
+                    [
+                        claimed.clone(),
+                        not_claimed.clone(),
+                        not_claimed.clone(),
+                        claimed.clone(),
+                        not_claimed.clone(),
+                    ]
+                    .into(),
+                    6,
+                );
                 assert_eq!(
                     shifting_progress_after_1,
                     expected_shifting_progress_after_1
@@ -80,10 +103,24 @@ fn claim_progress_cleanup_test() {
                 args.push(managed_address!(&first_user));
                 sc.clear_old_storage_flags(args);
 
+                let not_claimed = ClaimFlag::NotClaimed;
+                let claimed = ClaimFlag::Claimed {
+                    unclaimed_projects: ManagedVec::new(),
+                };
+
                 // check shifting progress
                 let shifting_progress = sc.claim_progress(&managed_address!(&first_user)).get();
-                let expected_shifting_progress =
-                    ShiftingClaimProgress::new([true, true, false, false, true], 5);
+                let expected_shifting_progress = ShiftingClaimProgress::new(
+                    [
+                        claimed.clone(),
+                        claimed.clone(),
+                        not_claimed.clone(),
+                        not_claimed.clone(),
+                        claimed.clone(),
+                    ]
+                    .into(),
+                    5,
+                );
                 assert_eq!(shifting_progress, expected_shifting_progress);
 
                 assert!(!sc

--- a/metabonding/tests/claim_progress_test.rs
+++ b/metabonding/tests/claim_progress_test.rs
@@ -56,8 +56,8 @@ fn claim_progress_migration_test() {
                         claimed.clone(),
                         not_claimed.clone(),
                         not_claimed.clone(),
-                        claimed.clone(),
-                        not_claimed.clone(),
+                        claimed,
+                        not_claimed,
                     ]
                     .into(),
                     6,
@@ -115,8 +115,8 @@ fn claim_progress_cleanup_test() {
                         claimed.clone(),
                         claimed.clone(),
                         not_claimed.clone(),
-                        not_claimed.clone(),
-                        claimed.clone(),
+                        not_claimed,
+                        claimed,
                     ]
                     .into(),
                     5,

--- a/metabonding/tests/metabonding_setup/mod.rs
+++ b/metabonding/tests/metabonding_setup/mod.rs
@@ -5,6 +5,7 @@ use metabonding::{
     common_storage::{CommonStorageModule, EPOCHS_IN_WEEK},
     rewards::Week,
 };
+use multiversx_sc::types::ManagedVec;
 use multiversx_sc::{
     api::ED25519_SIGNATURE_BYTE_LEN,
     codec::multi_types::OptionalValue,
@@ -356,6 +357,37 @@ where
                 );
 
                 let _ = sc.claim_rewards(managed_address!(caller), args);
+            })
+    }
+
+    pub fn call_claim_partial_rewards(
+        &mut self,
+        caller: &Address,
+        week: Week,
+        user_delegation_supply: u64,
+        user_lkmex_staked: u64,
+        signature: &[u8; ED25519_SIGNATURE_BYTE_LEN],
+        projects_to_claim: &[&[u8]],
+    ) -> TxResult {
+        self.b_mock
+            .execute_tx(caller, &self.mb_wrapper, &rust_biguint!(0), |sc| {
+                let mut args = MultiValueEncoded::new();
+                args.push(
+                    (
+                        week,
+                        managed_biguint!(user_delegation_supply),
+                        managed_biguint!(user_lkmex_staked),
+                        signature.into(),
+                    )
+                        .into(),
+                );
+
+                let mut ptc = ManagedVec::new();
+                for proj_id in projects_to_claim {
+                    ptc.push(managed_buffer!(*proj_id));
+                }
+
+                let _ = sc.claim_partial_rewards(managed_address!(caller), ptc, args);
             })
     }
 

--- a/metabonding/tests/metabonding_setup/mod.rs
+++ b/metabonding/tests/metabonding_setup/mod.rs
@@ -392,7 +392,8 @@ where
             .execute_query(&self.mb_wrapper, |sc| {
                 let result = sc.get_user_claimable_weeks(managed_address!(user_addr));
 
-                for week in &result.to_vec() {
+                for multi_value in result {
+                    let (week, _) = multi_value.into_tuple();
                     weeks.push(week);
                 }
             })

--- a/metabonding/tests/metabonding_setup/mod.rs
+++ b/metabonding/tests/metabonding_setup/mod.rs
@@ -256,7 +256,7 @@ where
 
         self.b_mock
             .execute_query(&self.mb_wrapper, |sc| {
-                let result = sc.get_all_project_ids();
+                let result = sc.get_all_project_ids_view();
 
                 for id in &result.to_vec() {
                     all_ids.push(id.to_boxed_bytes().as_slice().to_vec());


### PR DESCRIPTION
Add another claim endpoint, which allows selecting only specific tokens to claim. This made it so we needed to change how the claim flags, previously a simple boolean flag are stored:
- changing the claim flags to either keep `NotClaimed`, previously `false`, or `Claimed` and list of unclaimed tokens, previously `true`
- 